### PR TITLE
Remove ramda dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-- '6'
-- '7'
-- '8'
-- '9'
+- 10
+- 12
+- 14
 cache:
   directories:
   - node_modules

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ import { Inlet, Outlet, ConduitProvider } from "react-conduit";
 
 ## CHANGELOG
 
+### next
+
+* Remove ramda dependency.
+
 ### v3.0.0
 
 * [BREAKING] No longer supports React version &lt; 16.8.

--- a/babel.config.js
+++ b/babel.config.js
@@ -11,5 +11,5 @@ module.exports = {
     ],
     "@babel/react",
   ],
-  plugins: ["@babel/plugin-proposal-class-properties", "babel-plugin-ramda"],
+  plugins: ["@babel/plugin-proposal-class-properties"],
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "ramda": "^0.26.1",
     "uuid": "^3.4.0"
   },
   "peerDependencies": {
@@ -40,12 +39,11 @@
   "devDependencies": {
     "@babel/cli": "^7.8.3",
     "@babel/core": "^7.8.3",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
     "@babel/preset-react": "^7.8.3",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^25.1.0",
-    "babel-plugin-ramda": "^2.0.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "enzyme-to-json": "^3.4.3",

--- a/src/poor-man-ramda.js
+++ b/src/poor-man-ramda.js
@@ -1,0 +1,10 @@
+/* global Reflect */
+export const values = obj => Object.values(obj);
+
+export const assoc = (k, v, obj) => ({ ...obj, [k]: v });
+
+export const dissoc = (k, obj) => {
+  const ret = { ...obj };
+  Reflect.deleteProperty(ret, k);
+  return ret;
+};

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,6 +1,6 @@
 import createFragment from "react-addons-create-fragment";
-import { assoc, dissoc, values } from "ramda";
 import Conduit from "./conduit";
+import { assoc, dissoc, values } from "./poor-man-ramda";
 
 class Registry {
   state = {

--- a/test/poor-man-ramda.test.js
+++ b/test/poor-man-ramda.test.js
@@ -1,0 +1,38 @@
+import { values, assoc, dissoc } from "../src/poor-man-ramda";
+
+describe("values", () => {
+  it("returns the object values", () => {
+    expect(values({})).toEqual([]);
+    expect(values({ a: 1, b: 2, c: 3 })).toEqual([1, 2, 3]);
+  });
+});
+
+describe("assoc", () => {
+  it("adds a key to an object", () => {
+    const o = { a: 1, b: 2 };
+    const a1 = assoc("b", 3, o);
+    const a2 = assoc("c", 3, o);
+
+    expect(a1).not.toBe(o);
+    expect(a2).not.toBe(o);
+
+    expect(o).toEqual({ a: 1, b: 2 });
+    expect(a1).toEqual({ a: 1, b: 3 });
+    expect(a2).toEqual({ a: 1, b: 2, c: 3 });
+  });
+});
+
+describe("dissoc", () => {
+  it("removes a key from an object", () => {
+    const o = { a: 1, b: 2, c: 3 };
+    const d1 = dissoc("a", o);
+    const d2 = dissoc("d", o);
+
+    expect(d1).not.toBe(o);
+    expect(d2).not.toBe(o);
+
+    expect(o).toEqual({ a: 1, b: 2, c: 3 });
+    expect(d1).toEqual({ b: 2, c: 3 });
+    expect(d2).toEqual(o);
+  });
+});


### PR DESCRIPTION
Ramda values, assoc and dissoc functions were in use.
However they can do much more than the library really needed,
which can be achieved with standard syntax.

* Add poor man versions of values, assoc and dissoc using
  standard syntax. Just what's needed.
* Remove Ramda
* Remove Ramda plugin from babel